### PR TITLE
[Fix] Max width of active item when navbar is collapsed

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -77,7 +77,7 @@ h2 {
 }
 .navbar-dark .navbar-nav .nav-item.active .nav-link {
   border-bottom: 2px solid white;
-  width:max-content;
+  width: max-content;
 }
 .toc-card {
   width: 18rem;

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -77,10 +77,6 @@ h2 {
 }
 .navbar-dark .navbar-nav .nav-item.active .nav-link {
   border-bottom: 2px solid white;
-}
-@media only screen and (max-device-width: 1198px) {
-  .navbar-dark .navbar-nav .nav-item.active .nav-link {
-  border-bottom: 2px solid #fbfbfb;
   width:max-content;
 }
 .toc-card {

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -78,6 +78,11 @@ h2 {
 .navbar-dark .navbar-nav .nav-item.active .nav-link {
   border-bottom: 2px solid white;
 }
+@media only screen and (max-device-width: 1198px) {
+  .navbar-dark .navbar-nav .nav-item.active .nav-link {
+  border-bottom: 2px solid #fbfbfb;
+  width:max-content;
+}
 .toc-card {
   width: 18rem;
   margin-bottom: 1rem;


### PR DESCRIPTION

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of creativecommons.github.io-source.
- [x] I tried building the site using Lektor locally and verified that there are no build errors.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. -->

Closes #XXXXX

<!-- You may add your description of the pull request underneath this line. -->
This fixes the max width of the active item when the navbar is collapsed on mobile (see screenshot)
<img width="258" alt="screen shot 2019-03-06 at 11 42 04 pm" src="https://user-images.githubusercontent.com/26908305/53932858-d4f3c500-4069-11e9-9c1e-229d22e06fe3.png">
