### PR TITLE
[Fix] improve styling for active nav links when navbar has collapsed.#25

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -64,6 +64,7 @@ h2 {
 }
 .nav-item, .dropdown-item {
   font-size: 1.2em;
+  text-align: center;
 }
 .dropdown:hover .dropdown-menu {
   display: block;
@@ -71,12 +72,24 @@ h2 {
 .dropdown-menu {
   margin-top: 0px;
 }
+.nav-item:hover{
+  background: #e15803!important;
+}
 .navbar-dark .navbar-nav .nav-item .nav-link {
-  padding-bottom: .3rem;
   color: white;
+  line-height: 1rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.6)
+}
+.navbar-dark .navbar-toggler {
+    border-color: rgba(255,255,255);
 }
 .navbar-dark .navbar-nav .nav-item.active .nav-link {
-  border-bottom: 2px solid white;
+  background: #e15803!important;
+}
+@media only screen and (max-width : 1200px) {
+.navbar-dark .navbar-nav .nav-item .nav-link {
+  border: None;
+  text-align: center;
 }
 .toc-card {
   width: 18rem;


### PR DESCRIPTION
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of creativecommons.github.io-source.
- [x] I tried building the site using Lektor locally and verified that there are no build errors.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. -->

Closes #25 

The design of  https://creativecommons.org website navbar blended perfectly with this. 
Thanks @kgodey for suggesting it.
(screenshots below)

<!-- You may add your description of the pull request underneath this line. -->
![updatenav](https://user-images.githubusercontent.com/34679965/53941852-3ace6400-40df-11e9-9631-d6855f104f1a.png)


![updatecollapser](https://user-images.githubusercontent.com/34679965/53941856-3c982780-40df-11e9-8731-3e53857fa3d1.png)


![editthis](https://user-images.githubusercontent.com/34679965/53941863-43269f00-40df-11e9-8b52-a16bcf5f1ec1.png)


If this fix can be improved, tell me. I would love to improve it.