### PR TITLE
Fixed anchors for sub-items in TOC

### DIFF
--- a/templates/page-with-toc.html
+++ b/templates/page-with-toc.html
@@ -9,7 +9,7 @@
           {% if item.children %}
             <ul class="toc list-unstyled pl-4">
               {% for subitem in item.children %}
-                <li><a href="#{{ item.anchor }}">{{ subitem.title }}</a></li>
+                <li><a href="#{{ subitem.anchor }}">{{ subitem.title }}</a></li>
               {% endfor %}
             </ul>
           {% endif %}


### PR DESCRIPTION

<!-- Add a description of the pull request underneath this line. -->
This template fix links each sub-item to the appropriate anchor. See the TOC box on http://creativecommons.github.io/contributing-code/, and you'll notice all the sub-item anchor links are currently not right.

Before this update:
<img width="555" alt="before" src="https://user-images.githubusercontent.com/26908305/54083717-e9e88680-42fd-11e9-9897-abb13c5eaf12.png">


After:
<img width="660" alt="after" src="https://user-images.githubusercontent.com/26908305/54083719-ef45d100-42fd-11e9-8e05-9a475a34e0fd.png">
<!-- If your pull request addresses an existing GitHub issue, replace the XX below with the issue number. -->

Closes #XX

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

**Checklist**  
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of creativecommons.github.io-source.
- [x] I tried building the site using Lektor locally and verified that there are no build errors.

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.