### PR TITLE
integrate lektor-atom plugin for CC technical blog.

### DIFF
--- a/.lektorproject
+++ b/.lektorproject
@@ -8,3 +8,4 @@ target = ghpages+https://creativecommons/creativecommons.github.io
 lektor-markdown-header-anchors = 0.3.1
 lektor-google-analytics = 0.1.3
 lektor-webpack-support = 0.5
+lektor-atom = 0.3

--- a/.lektorproject
+++ b/.lektorproject
@@ -1,5 +1,7 @@
 [project]
 name = creativecommons.github.io
+url_style = absolute
+url = http://creativecommons.github.io/
 
 [servers.ghpages]
 target = ghpages+https://creativecommons/creativecommons.github.io

--- a/configs/atom.ini
+++ b/configs/atom.ini
@@ -1,7 +1,7 @@
 [blog]
 name = CC technical blog
 source_path = /
-url_path = /feed.xml
+url_path = /blog/feed.xml
 blog_summary_field = description
 items = site.query('/blog/entries')
 item_title_field = title

--- a/configs/atom.ini
+++ b/configs/atom.ini
@@ -1,0 +1,11 @@
+[blog]
+name = CC technical blog
+source_path = /
+url_path = /feed.xml
+blog_summary_field = description
+items = site.query('/blog/entries')
+item_title_field = title
+item_body_field = body
+item_author_field = author
+item_date_field = pub_date
+item_model = blog-post

--- a/models/blog-post.ini
+++ b/models/blog-post.ini
@@ -19,9 +19,7 @@ width = 1/2
 
 [fields.author]
 label = Author
-type = select
-source = site.query('/authors')
-width = 1/2
+type = string
 
 [fields.body]
 label = Body

--- a/templates/blog-post.html
+++ b/templates/blog-post.html
@@ -3,6 +3,7 @@
 {% block header %}{{ this.parent.title }}{% endblock %}
 {% block body %}
   <h2 class="mb-0">{{ this.title }}</h2>
+  {{ check_file('content' + this.parent.parent.path + '/authors/' + this.author + '/contents.lr') }}
   <p class="meta text-muted mt-0">by <a href="{{ this.parent.parent.children.get('authors').path + '/' + this.author }}">{{ this.author }}</a>
   on {{ this.pub_date|dateformat('EEEE, yyyy ''MMMM d') }}</p>
   <div class="body">{{ this.body }}</div>


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #75 

**Description**
<!-- Add your description below. -->
- add [lektor-atom](https://www.getlektor.com/plugins/lektor-atom/) plugin. Using it, we can easily create multiple feeds.
- add `[blog]` feed for CC technical blog `content/blog`.
- Add absolute url in project config to remove `E feed.xml (RuntimeError: To use absolute URLs you need to configure the URL in the project config.)` error.
- The feed for blog will be at `creativecommons.github.io/feed.xml`. 

**Other information**
<!-- Add any other information below or delete the "Other Information" line entirely. -->
- I also added the `check_file()` function in `blog-post.html` to ensure that we have created an author before publishing a blog post.
- The `select` type of author field in `blog-post.ini` was querying the now absent `/authors`. Changed the type to `string`. 

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
