### PR TITLE
Fixed e-mail link

### DIFF
--- a/content/community/code-of-conduct/enforcement/contents.lr
+++ b/content/community/code-of-conduct/enforcement/contents.lr
@@ -16,7 +16,7 @@ This document provides incident reporting guidelines and an enforcement manual f
 ## Reporting Guidelines
 
 If you believe someone is violating the code of conduct, we ask that you report it to Creative Commons by emailing 
-**[conduct@creativecommons.org]((mailto:conduct@creativecommons.org)**. **All reports will be kept confidential.** In some cases we may determine that a public statement will need to be made, which the committee may make in its discretion. The identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+**[conduct@creativecommons.org](mailto:conduct@creativecommons.org)**. **All reports will be kept confidential.** In some cases we may determine that a public statement will need to be made, which the committee may make in its discretion. The identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
 
 **If you believe anyone is in physical danger, please notify appropriate emergency personnel first.** If you are unsure what proper authorities  are appropriate, please include this in your report and we will attempt to notify them.
 


### PR DESCRIPTION
**Description**
<!-- Add your description below. -->
Removed a stray parenthesis in the e-mail link for conduct@creativecommons.org which was leading to a 404 error page when clicked at http://creativecommons.github.io/community/code-of-conduct/enforcement/

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.