### PR TITLE
update slack channel names

### DIFF
--- a/content/community/contents.lr
+++ b/content/community/contents.lr
@@ -33,7 +33,7 @@ The channels most relevant to CC's developer community are:
     </tr>
     <tr>
       <td><code>#cc-dev-wordpress</code</td>
-      <td>Discussion related to <a href="https://github.com/creativecommons/wp-plugin-creativecommons">the CC WordPress plugin</a> (a <a href="/gsoc-2019/">GSoC 2019</a> project)</td>
+      <td>Discussion related to <a href="https://github.com/creativecommons/wp-plugin-creativecommons">the CC WordPress plugin</a>.</td>
     </tr>
     <tr>
       <td><code>#cc-dev-linkchecker</code</td>
@@ -48,21 +48,29 @@ The channels most relevant to CC's developer community are:
       <td>General usability discussions, seeking feedback on new releases of CC products from the community</td>
     </tr>
     <tr>
-      <td><code>#gsoc-browser-ext</code</td>
-      <td>Discussion related to the <a href="https://github.com/creativecommons/ccsearch-browser-extension">CC Search browser extension</a> (a <a href="/gsoc-2019/">GSoC 2019</a> project)</td>
+      <td><code>#cc-dev-browser-ext</code</td>
+      <td>Discussion related to the <a href="https://github.com/creativecommons/ccsearch-browser-extension">CC Search browser extension</a>.</td>
     </tr>
     <tr>
-      <td><code>#gsoc-cc-catalog-viz</code</td>
-      <td>Discussion related to the <a href="https://github.com/creativecommons/cccatalog-dataviz">CC Catalog visualizations</a> (a <a href="/gsoc-2019/">GSoC 2019</a> project)</td>
+      <td><code>#cc-dev-cc-catalog-viz</code</td>
+      <td>Discussion related to the <a href="https://github.com/creativecommons/cccatalog-dataviz">CC Catalog visualizations</a>.</td>
     </tr>
     <tr>
-      <td><code>#gsoc-cc-vocabulary</code</td>
-      <td>Discussion related to <a href="https://github.com/creativecommons/cc-vocabulary">CC Vocabulary</a> (a <a href="/gsoc-2019/">GSoC 2019</a> project)</td>
+      <td><code>#cc-dev-cc-vocabulary</code</td>
+      <td>Discussion related to <a href="https://github.com/creativecommons/cc-vocabulary">CC Vocabulary</a>.</td>
     </tr>
     <tr>
-      <td><code>#gsoc-license-chooser</code</td>
-      <td>Discussion related to the <a href="https://github.com/creativecommons/cc-chooser">new CC license chooser</a> (a <a href="/gsoc-2019/">GSoC 2019</a> project)</td>
+      <td><code>#cc-dev-license-chooser</code</td>
+      <td>Discussion related to the <a href="https://github.com/creativecommons/cc-chooser">new CC license chooser</a>.</td>
     </tr>
+    <tr>
+      <td><code>#cc-outreachy-platform-toolkit</code</td>
+      <td>Discussion related to <a href="https://github.com/creativecommons/mp">CC Tookit</a>.</td>
+    </tr>        
+     <tr>
+      <td><code>#cc-outreachy-faq</code</td>
+      <td>Discussion related to the <a href="https://github.com/creativecommons/faq/">CC FAQ</a>.</td>
+    </tr>      
   </tbody>
 </table>
 

--- a/content/community/contents.lr
+++ b/content/community/contents.lr
@@ -48,7 +48,7 @@ The channels most relevant to CC's developer community are:
       <td>General usability discussions, seeking feedback on new releases of CC products from the community</td>
     </tr>
     <tr>
-      <td><code>#cc-dev-browser-ext</code</td>
+      <td><code>#cc-dev-browser-extension</code</td>
       <td>Discussion related to the <a href="https://github.com/creativecommons/ccsearch-browser-extension">CC Search browser extension</a>.</td>
     </tr>
     <tr>
@@ -65,11 +65,11 @@ The channels most relevant to CC's developer community are:
     </tr>
     <tr>
       <td><code>#cc-outreachy-platform-toolkit</code</td>
-      <td>Discussion related to <a href="https://github.com/creativecommons/mp">CC Tookit</a>.</td>
+      <td>Discussion related to the <a href="https://github.com/creativecommons/mp">CC Platform Tookit</a> Outreachy project.</td>
     </tr>        
      <tr>
       <td><code>#cc-outreachy-faq</code</td>
-      <td>Discussion related to the <a href="https://github.com/creativecommons/faq/">CC FAQ</a>.</td>
+      <td>Discussion related to the <a href="https://github.com/creativecommons/faq/">CC FAQ</a> Outreachy project.</td>
     </tr>      
   </tbody>
 </table>


### PR DESCRIPTION
**Description**
An update of Slack channel names as gsoc 2019 has finished.
