### PR TITLE
add creativecommons.org link to menu (in dropdown)

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -31,8 +31,16 @@
         
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
               <ul class="navbar-nav">
-                <li class="nav-item{% if this._path == '/' %} active{% endif%}">
-                  <a class="nav-link" href="{{ '/'|url }}">Home</a>
+                <li class="nav-item dropdown{% if this._path == '/' %} active{% endif%}">
+                  <a class="nav-link" href="#" id="navbarHomeDropdown" role="button">Home</a>
+                  <div class="dropdown-menu" aria-labelledby="navbarHomeDropdown">
+                    {% for href, title in [
+                      ['https://creativecommons.org', 'Creative Commons'],
+                      ['/', 'Creative Commons Open Source'],
+                    ] %}
+                      <a href="{{ href }}" class="dropdown-item">{{ title }}</a>
+                    {% endfor %}
+                  </div>
                 </li>
                 <li class="nav-item dropdown {% if this.is_child_of('/contributing-code') %} active{% endif%}">
                   <a class="nav-link" href="#" id="navbarContributingCodeDropdown" role="button">Contributing Code</a>


### PR DESCRIPTION
Fixes #103 

**Description**
This provide an easy way to go to creativecommons.org from CC Open Source pages.

**Other information**
I made this proposal: create a submenu below **Home**.
![Captura de pantalla de 2019-10-14 18-32-32](https://user-images.githubusercontent.com/9145885/66788523-e2054c00-eeb5-11e9-8e21-12b3599070b3.png)

I tried adding the link directly on first line (last link, **CC**) but it doesn't look so good, **Contributing Code** makes a break of line.
![Captura de pantalla de 2019-10-14 18-13-30](https://user-images.githubusercontent.com/9145885/66788631-4f18e180-eeb6-11e9-8001-03d986d7d6d7.png)


**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<details>
<summary>Developer Certificate of Origin Version 1.1</summary>

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</details>