### PR TITLE
Add two more redirects for other Netlify based repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Here's how the code is structured in the top level of the repository:
 - `/cc-vocabulary/` to https://cc-vocabulary.netlify.com/
   - Added so that the `opensource.creativecommons.org/cc-vocabulary/` will
     continue to work with that project moving to utilize Netlify.
+- `/cc-vue-vocabulary` to https://cc-vue-vocabulary.netlify.com/
+  - Added so that the `opensource.creativecommons.org/cc-vue-vocabulary/` will
+    continue to work with that project moving to utilize Netlify.
+- `/cc-fonts` to https://cc-fonts.netlify.com/
+  - Added so that the `opensource.creativecommons.org/cc-fonts/` will
+    continue to work with that project moving to utilize Netlify.
 
 
 ## License

--- a/content/cc-fonts/contents.lr
+++ b/content/cc-fonts/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: https://cc-fonts.netlify.com/
+---
+_discoverable: no

--- a/content/cc-vue-vocabulary/contents.lr
+++ b/content/cc-vue-vocabulary/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: https://cc-vue-vocabulary.netlify.com/
+---
+_discoverable: no


### PR DESCRIPTION
## Description
Since two other repos, [Vue Vocabulary](https://github.com/creativecommons/vue-vocabulary) and [Fonts](https://github.com/creativecommons/fonts) are using, or planning to use, a Netlify-based CI/CD pipeline, it would be useful to have redirects for them as well from the Open Source at CC site.

## Other information
This is useful as we can pursue publishing the links as subdirectories of the **opensource.creativecommons.org** domain name which is more semantic compared to a **.netlify.com** subdomain.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
