### PR TITLE
Add link to intern guide and fix markup link

### DIFF
--- a/content/internships/intern-guide/contents.lr
+++ b/content/internships/intern-guide/contents.lr
@@ -27,7 +27,7 @@ Once the internship starts, here's what we expect of you:
 * Work 30-40 hours per week (or agree on a different plan with your mentor ahead of time).
 * Push code to GitHub frequently. Commit early and often.
 * Be available on Slack whenever you are working and post at least once a (work)day to talk about what you're working on that day.
-* Write a short update on your work **every two weeks** and post it to the CC technical blog ([instructions are here(/community/write-a-blog-post)). To get a sense of how theses posts are written and how the projects evolved, you can read entries done by previous [Outreachy](https://opensource.creativecommons.org/blog/categories/outreachy/) or [Google Summer of Code](https://opensource.creativecommons.org/blog/categories/gsoc/) interns.
+* Write a short update on your work **every two weeks** and post it to the CC technical blog ([instructions are here](/community/write-a-blog-post)). To get a sense of how theses posts are written and how the projects evolved, you can read entries done by previous [Outreachy](https://opensource.creativecommons.org/blog/categories/outreachy/) or [Google Summer of Code](https://opensource.creativecommons.org/blog/categories/gsoc/) interns.
 * Attend your weekly check-in with your mentor and any other meetings.
 * Be proactive about asking for help, especially when you're stuck.
 * Ensure that you're on track to delivering your project at the end of the work period. If you're not on track, talk with your mentor to come up with a new plan for the project well before the deadline.

--- a/content/internships/intern-guide/contents.lr
+++ b/content/internships/intern-guide/contents.lr
@@ -27,7 +27,7 @@ Once the internship starts, here's what we expect of you:
 * Work 30-40 hours per week (or agree on a different plan with your mentor ahead of time).
 * Push code to GitHub frequently. Commit early and often.
 * Be available on Slack whenever you are working and post at least once a (work)day to talk about what you're working on that day.
-* Write a short update on your work **every two weeks** and post it to the CC technical blog ([instructions are here(/community/write-a-blog-post)).
+* Write a short update on your work **every two weeks** and post it to the CC technical blog ([instructions are here(/community/write-a-blog-post)). To get a sense of how theses posts are written and how the projects evolved, you can read entries done by previous [Outreachy](https://opensource.creativecommons.org/blog/categories/outreachy/) or [Google Summer of Code](https://opensource.creativecommons.org/blog/categories/gsoc/) interns.
 * Attend your weekly check-in with your mentor and any other meetings.
 * Be proactive about asking for help, especially when you're stuck.
 * Ensure that you're on track to delivering your project at the end of the work period. If you're not on track, talk with your mentor to come up with a new plan for the project well before the deadline.

--- a/content/internships/intern-guide/contents.lr
+++ b/content/internships/intern-guide/contents.lr
@@ -27,7 +27,7 @@ Once the internship starts, here's what we expect of you:
 * Work 30-40 hours per week (or agree on a different plan with your mentor ahead of time).
 * Push code to GitHub frequently. Commit early and often.
 * Be available on Slack whenever you are working and post at least once a (work)day to talk about what you're working on that day.
-* Write a short update on your work **every two weeks** and post it to the CC technical blog ([instructions are here](/community/write-a-blog-post)). To get a sense of how theses posts are written and how the projects evolved, you can read entries done by previous [Outreachy](https://opensource.creativecommons.org/blog/categories/outreachy/) or [Google Summer of Code](https://opensource.creativecommons.org/blog/categories/gsoc/) interns.
+* Write a short update on your work **every two weeks** and post it to the CC technical blog ([instructions are here](/community/write-a-blog-post)). To get a sense of how these posts are written and how the projects evolved, you can read entries done by previous [Outreachy](https://opensource.creativecommons.org/blog/categories/outreachy/) or [Google Summer of Code](https://opensource.creativecommons.org/blog/categories/gsoc/) interns.
 * Attend your weekly check-in with your mentor and any other meetings.
 * Be proactive about asking for help, especially when you're stuck.
 * Ensure that you're on track to delivering your project at the end of the work period. If you're not on track, talk with your mentor to come up with a new plan for the project well before the deadline.


### PR DESCRIPTION

## Description

Includes link to blog posts tagged "Outreachy" and "GSOC" to the Intern Guide.
Fix markup to correctly link to CC technical blog


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
