### PR TITLE
Add "help wanted" issues link that filters out "in progress" issues to contributing page

### DIFF
--- a/content/contributing-code/contents.lr
+++ b/content/contributing-code/contents.lr
@@ -27,6 +27,7 @@ We track all our work via the GitHub issues associated with a repository and tha
 * Issues labeled **"help wanted"** or **"good first issue"** have been identified as available for community contribution. Feel free to work on issues labeled "good first issue" even if it is not your first issue.
     * Here's a list of [all issues labeled "good first issue"](https://github.com/search?q=org%3Acreativecommons+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     * Here are lists of [all issues labeled "help wanted"](https://github.com/search?q=org%3Acreativecommons+is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and [incomplete pull requests labeled "help wanted"](https://github.com/search?q=org%3Acreativecommons+is%3Apr+is%3Aopen+label%3A%22help+wanted%22)
+    * Here's a list of [all issues labeled "help wanted", and not labeled as "in progress"](https://github.com/search?q=org%3Acreativecommons+is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+-label%3A%22in+progress%22)
 * If the issue does not have either of those labels, it may still be open for contribution.
 
 Once you have identified an issue you'd like to work on, follow these steps:


### PR DESCRIPTION
## Description
This link takes advantage of the GH search syntax by using the `-` operator. By adding `-label:"in progress"`, we filter out everything with that label.

## Other information
<!-- Add any other information below or delete the "Other Information" line entirely. -->

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
