### PR TITLE
Fixed broken links on project ideas page to correctly point at vocabulary site.

### DIFF
--- a/content/internships/project-ideas-collection/legal-database/contents.lr
+++ b/content/internships/project-ideas-collection/legal-database/contents.lr
@@ -8,14 +8,14 @@ problem:
 CC maintains [a collection of case law and legal scholarship](https://labs.creativecommons.org/caselaw/) relevant to legal issues around Creative Commons licenses. Users can submit information, which is reviewed by a member of CC’s legal team and edited if necessary before publishing it to the live site. This tool currently has a number of issues:  
 *   publishing new data is a cumbersome manual process for both the legal and tech teams.
 *   there is no way to browse all resources on the site.
-*   It does not use [Vocabulary](http://opensource.creativecommons.org/cc-vocabulary/), CC’s new web design system.
+*   It does not use [Vocabulary](https://cc-vocabulary.netlify.com/), CC’s new web design system.
 ---
 expected_outcome:
 A new website, built using either WordPress or Django, that supports the following features:  
 *   The general public can submit legal information without a user account (the information collected should be identical to the current implementation).
 *   The legal team at CC can review and edit incoming information and approve it, at which point it goes live.
 *   All the legal information on the site should be browseable and searchable by keyword and country.
-*   The user-facing portion of the website should use [Vocabulary](http://opensource.creativecommons.org/cc-vocabulary/) components.
+*   The user-facing portion of the website should use [Vocabulary](https://cc-vocabulary.netlify.com/) components.
 ---
 internship_tasks:  
 *   Architect the backend of the legal database in either WordPress or Django, including researching appropriate plugins or libraries that will make the task easier.
@@ -31,7 +31,7 @@ Please specify the architecture and plugins/libraries that you’d like to use i
 resources:
 *   [Creative Commons Legal Database (beta)](https://labs.creativecommons.org/caselaw/)
 *   [Legal database GitHub repository](https://github.com/creativecommons/caselaw/)
-*   [Vocabulary](http://opensource.creativecommons.org/cc-vocabulary/)
+*   [Vocabulary](https://cc-vocabulary.netlify.com/)
 ---
 skills_recommended: CSS, Django, HTML, JavaScript, PHP, Python, WordPress (either Django/Python or WordPress/PHP, not both)
 ---

--- a/content/internships/project-ideas-collection/legal-database/contents.lr
+++ b/content/internships/project-ideas-collection/legal-database/contents.lr
@@ -8,7 +8,7 @@ problem:
 CC maintains [a collection of case law and legal scholarship](https://labs.creativecommons.org/caselaw/) relevant to legal issues around Creative Commons licenses. Users can submit information, which is reviewed by a member of CC’s legal team and edited if necessary before publishing it to the live site. This tool currently has a number of issues:  
 *   publishing new data is a cumbersome manual process for both the legal and tech teams.
 *   there is no way to browse all resources on the site.
-*   It does not use [Vocabulary](opensource.creativecommons.org/cc-vocabulary/), CC’s new web design system.
+*   It does not use [Vocabulary](http://opensource.creativecommons.org/cc-vocabulary/), CC’s new web design system.
 ---
 expected_outcome:
 A new website, built using either WordPress or Django, that supports the following features:  
@@ -31,7 +31,7 @@ Please specify the architecture and plugins/libraries that you’d like to use i
 resources:
 *   [Creative Commons Legal Database (beta)](https://labs.creativecommons.org/caselaw/)
 *   [Legal database GitHub repository](https://github.com/creativecommons/caselaw/)
-*   [Vocabulary](opensource.creativecommons.org/cc-vocabulary/)
+*   [Vocabulary](http://opensource.creativecommons.org/cc-vocabulary/)
 ---
 skills_recommended: CSS, Django, HTML, JavaScript, PHP, Python, WordPress (either Django/Python or WordPress/PHP, not both)
 ---


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #190 

## Description
Updated broken links to correctly point to https://cc-vocabulary.netlify.com/.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
