### PR TITLE
Add default styling for tables

### DIFF
--- a/configs/markdown-table.ini
+++ b/configs/markdown-table.ini
@@ -1,0 +1,3 @@
+[bootstrap_class]
+table = 'table table-striped'
+thead = 'thead-dark'

--- a/packages/markdown-table/.gitignore
+++ b/packages/markdown-table/.gitignore
@@ -1,0 +1,5 @@
+dist
+build
+*.pyc
+*.pyo
+*.egg-info

--- a/packages/markdown-table/.gitignore
+++ b/packages/markdown-table/.gitignore
@@ -1,5 +1,0 @@
-dist
-build
-*.pyc
-*.pyo
-*.egg-info

--- a/packages/markdown-table/README.md
+++ b/packages/markdown-table/README.md
@@ -1,14 +1,12 @@
 # markdown-table
 
-This plugin adds styling to markdown tables, by adding bootstrap classes.
-Styling can be applied to  ```<table>``` and ```thead```  by creating a configuration file
-named  ```markdown-table.ini``` in the ```configs``` directory.
+This plugin adds styling to markdown tables, by adding bootstrap classes. Styling can be applied to `<table>` and `thead` by creating a configuration file named `markdown-table.ini` in the `configs` directory.
 
 #### Example
 
-```
+```ini
 [bootstrap_class]
 table = 'table table-striped'
 thead = 'thead-dark'
 ```
-If not specified, the default styles ```'table table-striped``` and  ```thead-dark``` are applied.
+Unless specified, the default styles `table table-striped` and `thead-dark` are applied.

--- a/packages/markdown-table/README.md
+++ b/packages/markdown-table/README.md
@@ -1,0 +1,4 @@
+# markdown-table
+
+This is where a description of your plugin goes.
+Provide usage instructions here.

--- a/packages/markdown-table/README.md
+++ b/packages/markdown-table/README.md
@@ -1,4 +1,14 @@
 # markdown-table
 
-This is where a description of your plugin goes.
-Provide usage instructions here.
+This plugin adds styling to markdown tables, by adding bootstrap classes.
+Styling can be applied to  ```<table>``` and ```thead```  by creating a configuration file
+named  ```markdown-table.ini``` in the ```configs``` directory.
+
+#### Example
+
+```
+[bootstrap_class]
+table = 'table table-striped'
+thead = 'thead-dark'
+```
+If not specified, the default styles ```'table table-striped``` and  ```thead-dark``` are applied.

--- a/packages/markdown-table/lektor_markdown_table.py
+++ b/packages/markdown-table/lektor_markdown_table.py
@@ -4,7 +4,7 @@ from lektor.pluginsystem import Plugin
 
 class MarkdownTablePlugin(Plugin):
     name = 'markdown-table'
-    description = u'Add your description here.'
+    description = u'This plugin adds styling to markdown tables'
 
     def get_style(self):
         table_class = self.get_config().get('bootstrap_class.table', 'table table-striped')

--- a/packages/markdown-table/lektor_markdown_table.py
+++ b/packages/markdown-table/lektor_markdown_table.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from lektor.pluginsystem import Plugin
+
+
+class MarkdownTablePlugin(Plugin):
+    name = 'markdown-table'
+    description = u'Add your description here.'
+
+    def get_style(self):
+        table_class = self.get_config().get('bootstrap_class.table', 'table table-striped')
+        thead_class = self.get_config().get('bootstrap_class.thead', 'thead-dark')
+
+        return [table_class, thead_class]
+
+    def style_table(self, header, body):
+        table_class, thead_class = self.get_style()
+        return (
+            '<table class="%s">\n<thead class="%s">%s</thead>\n'
+            '<tbody>\n%s</tbody>\n</table>\n'
+        ) % (table_class, thead_class, header, body)
+
+    def on_markdown_config(self, config, **extra):
+        class StyleTableMixin(object):
+            def table(ren, header, body):
+                return self.style_table(header, body)
+        config.renderer_mixins.append(StyleTableMixin)

--- a/packages/markdown-table/lektor_markdown_table.py
+++ b/packages/markdown-table/lektor_markdown_table.py
@@ -3,12 +3,16 @@ from lektor.pluginsystem import Plugin
 
 
 class MarkdownTablePlugin(Plugin):
-    name = 'markdown-table'
-    description = u'This plugin adds styling to markdown tables'
+    name = "markdown-table"
+    description = "This plugin adds styling to markdown tables"
 
     def get_style(self):
-        table_class = self.get_config().get('bootstrap_class.table', 'table table-striped')
-        thead_class = self.get_config().get('bootstrap_class.thead', 'thead-dark')
+        table_class = self.get_config().get(
+            "bootstrap_class.table", "table table-striped"
+        )
+        thead_class = self.get_config().get(
+            "bootstrap_class.thead", "thead-dark"
+        )
 
         return [table_class, thead_class]
 
@@ -16,11 +20,12 @@ class MarkdownTablePlugin(Plugin):
         table_class, thead_class = self.get_style()
         return (
             '<table class="%s">\n<thead class="%s">%s</thead>\n'
-            '<tbody>\n%s</tbody>\n</table>\n'
+            "<tbody>\n%s</tbody>\n</table>\n"
         ) % (table_class, thead_class, header, body)
 
     def on_markdown_config(self, config, **extra):
         class StyleTableMixin(object):
             def table(ren, header, body):
                 return self.style_table(header, body)
+
         config.renderer_mixins.append(StyleTableMixin)

--- a/packages/markdown-table/setup.py
+++ b/packages/markdown-table/setup.py
@@ -1,0 +1,38 @@
+import ast
+import io
+import re
+
+from setuptools import setup, find_packages
+
+with io.open('README.md', 'rt', encoding="utf8") as f:
+    readme = f.read()
+
+_description_re = re.compile(r'description\s+=\s+(?P<description>.*)')
+
+with open('lektor_markdown_table.py', 'rb') as f:
+    description = str(ast.literal_eval(_description_re.search(
+        f.read().decode('utf-8')).group(1)))
+
+setup(
+    author='Shubham Pandey',
+    author_email='shubhampcpandey13@gmail.com',
+    description=description,
+    keywords='Lektor plugin',
+    license='MIT',
+    long_description=readme,
+    long_description_content_type='text/markdown',
+    name='lektor-markdown-table',
+    packages=find_packages(),
+    py_modules=['lektor_markdown_table'],
+    # url='[link to your repository]',
+    version='0.1',
+    classifiers=[
+        'Framework :: Lektor',
+        'Environment :: Plugins',
+    ],
+    entry_points={
+        'lektor.plugins': [
+            'markdown-table = lektor_markdown_table:MarkdownTablePlugin',
+        ]
+    }
+)

--- a/packages/markdown-table/setup.py
+++ b/packages/markdown-table/setup.py
@@ -1,38 +1,30 @@
-import ast
-import io
-import re
-
 from setuptools import setup, find_packages
+from os import path
 
-with io.open('README.md', 'rt', encoding="utf8") as f:
-    readme = f.read()
 
-_description_re = re.compile(r'description\s+=\s+(?P<description>.*)')
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
 
-with open('lektor_markdown_table.py', 'rb') as f:
-    description = str(ast.literal_eval(_description_re.search(
-        f.read().decode('utf-8')).group(1)))
+description = "This plugin adds styling to markdown tables"
 
 setup(
-    author='Shubham Pandey',
-    author_email='shubhampcpandey13@gmail.com',
+    author="Shubham Pandey",
+    author_email="shubhampcpandey13@gmail.com",
     description=description,
-    keywords='Lektor plugin',
-    license='MIT',
-    long_description=readme,
-    long_description_content_type='text/markdown',
-    name='lektor-markdown-table',
+    keywords="Lektor plugin",
+    license="MIT",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    name="lektor-markdown-table",
     packages=find_packages(),
-    py_modules=['lektor_markdown_table'],
-    # url='[link to your repository]',
-    version='0.1',
-    classifiers=[
-        'Framework :: Lektor',
-        'Environment :: Plugins',
-    ],
+    py_modules=["lektor_markdown_table"],
+    url="https://github.com/sp35/lektor-markdown-table",
+    version="0.1",
+    classifiers=["Framework :: Lektor", "Environment :: Plugins", ],
     entry_points={
-        'lektor.plugins': [
-            'markdown-table = lektor_markdown_table:MarkdownTablePlugin',
+        "lektor.plugins": [
+            "markdown-table = lektor_markdown_table:MarkdownTablePlugin",
         ]
-    }
+    },
 )


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #225  by @TimidRobot 

## Description
Currently, there are no default styling for markdown tables.
This new Lektor plugin uses the required Bootstrap classes - ```thead-dark``` and ```table table-striped```.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
![Screenshot from 2020-04-09 03-45-09](https://user-images.githubusercontent.com/51958314/78839072-43494a80-7a15-11ea-8763-fe4e84fd7b96.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
