### PR TITLE
Fix the grammer mistake on Code of Conduct page

### DIFF
--- a/content/community/code-of-conduct/contents.lr
+++ b/content/community/code-of-conduct/contents.lr
@@ -13,7 +13,7 @@ The following Code of Conduct applies to all digital spaces managed by the Creat
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
+contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
@@ -64,7 +64,7 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing or otherwise unacceptable behavior may be
 reported by contacting the project team at **[conduct@creativecommons.org]((mailto:conduct@creativecommons.org)**. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
@@ -84,4 +84,3 @@ available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.ht
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq.
-


### PR DESCRIPTION
In the Reference of #256 

fix the mistake