### PR TITLE
Add '@creativecommons/vocabulary' to the project

### DIFF
--- a/webpack/package-lock.json
+++ b/webpack/package-lock.json
@@ -280,6 +280,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@creativecommons/vocabulary": {
+      "version": "1.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@creativecommons/vocabulary/-/vocabulary-1.0.0-beta.14.tgz",
+      "integrity": "sha512-Liu1iTKvru6Qm3QzMkPx6Dy/eCN/E6FTVpC4Kvw7NSeJe3xK88YbK2l0l/sadtuDHUAuQjBO1IZ2IYknWCjccA==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.9.0",
+    "@creativecommons/vocabulary": "^1.0.0-beta.14",
     "autoprefixer": "^9.7.5",
     "babel-loader": "^8.1.0",
     "css-loader": "^2.1.1",


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
This adds '@creativecommons/vocabulary' to the repo. 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Installed 1.0.0-beta.14 version for the '@creativecommons/vocabulary'.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
