### PR TITLE
Add link to cc-dev-licenses slack channel

### DIFF
--- a/content/community/contents.lr
+++ b/content/community/contents.lr
@@ -82,6 +82,10 @@ The channels most relevant to CC's developer community are:
       <td><code>#cc-usability</code</td>
       <td>General usability discussions, seeking feedback on new releases of CC products from the community.</td>
     </tr>
+    <tr>
+      <td><code>#cc-licenses-dev</code</td>
+      <td>Discussion of the <a href="https://github.com/creativecommons/cc-licenses">CC License infrastructure overhaul project</a>.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/content/community/contents.lr
+++ b/content/community/contents.lr
@@ -84,7 +84,7 @@ The channels most relevant to CC's developer community are:
     </tr>
     <tr>
       <td><code>#cc-licenses-dev</code</td>
-      <td>Discussion of the <a href="https://github.com/creativecommons/cc-licenses">CC License infrastructure overhaul project</a>.</td>
+      <td>Discussion of the <a href="https://github.com/creativecommons/cc-licenses">CC license infrastructure overhaul project</a>.</td>
     </tr>
   </tbody>
 </table>

--- a/content/community/contents.lr
+++ b/content/community/contents.lr
@@ -83,7 +83,7 @@ The channels most relevant to CC's developer community are:
       <td>General usability discussions, seeking feedback on new releases of CC products from the community.</td>
     </tr>
     <tr>
-      <td><code>#cc-licenses-dev</code</td>
+      <td><code>#cc-dev-licenses</code</td>
       <td>Discussion of the <a href="https://github.com/creativecommons/cc-licenses">CC license infrastructure overhaul project</a>.</td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Description
Add link to cc-licenses-dev slack channel to the Community page.
