### PR TITLE
Sticky Table of Contents

### DIFF
--- a/themes/vocabulary_theme/templates/page-with-toc.html
+++ b/themes/vocabulary_theme/templates/page-with-toc.html
@@ -85,7 +85,7 @@
               </aside>
             {% endif %}
           </div>
-          <div class="row">
+          <div class="row padding-bottom-normal sticky-top">
             <h4 class="b-header">On this page</h4>
             <aside class="menu table-of-contents">
               <ul class="menu-list">

--- a/webpack/sass/main.scss
+++ b/webpack/sass/main.scss
@@ -550,7 +550,7 @@ code {
 
     .project-idea {
       @extend .padding-bottom-xl;
-      
+
       .column {
         @extend .padding-top-normal;
       }
@@ -577,7 +577,7 @@ code {
       @extend .caption;
 
       text-decoration: none;
-    
+
       .icon {
         @extend .padding-right-small;
       }
@@ -592,4 +592,10 @@ code {
     @extend .padding-top-xl;
     @extend .padding-bottom-xxl;
   }
+}
+
+// Sticky utility function
+.sticky-top {
+  position: sticky;
+  top: 0;
 }


### PR DESCRIPTION
Fixes #396 

## Description

Makes the 'On this page' table of contents sticky. I didn't do the _entire sidebar_ because sticky items that are too tall can mean users can't access some of the lower items.

Also adds a global `.sticky-top` css class that can be used elsewhere.

Note, this does not have any effect on mobile displays.

## Screenshots

![Kapture 2020-08-06 at 11 55 53](https://user-images.githubusercontent.com/6351754/89553798-f9fae300-d7db-11ea-805a-16ff90ea594e.gif)




## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
