### PR TITLE
update vocabulary version.

### DIFF
--- a/webpack/package-lock.json
+++ b/webpack/package-lock.json
@@ -281,9 +281,9 @@
       }
     },
     "@creativecommons/vocabulary": {
-      "version": "2020.7.2",
-      "resolved": "https://registry.npmjs.org/@creativecommons/vocabulary/-/vocabulary-2020.7.2.tgz",
-      "integrity": "sha512-0sDdEdD6DWD4RjfgbCgVobS0SmY2bRFC8KDeoJ4fBbtxvBs+ix70eJG7jxQCYXHmUH07gPvAFTvIlvVJV02UOA==",
+      "version": "2020.8.3",
+      "resolved": "https://registry.npmjs.org/@creativecommons/vocabulary/-/vocabulary-2020.8.3.tgz",
+      "integrity": "sha512-dtHGvK863apfWVZ7Z3dWDJ10EepQ2Z2FLZaNUjbLXq4BiHno+lg7bCQpUO3IHvEoRVLKyowMAhZRRfyR1oFZmg==",
       "dev": true
     },
     "@webassemblyjs/ast": {

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.9.0",
-    "@creativecommons/vocabulary": "^2020.7.2",
+    "@creativecommons/vocabulary": "^2020.8.3",
     "autoprefixer": "^9.7.5",
     "babel-loader": "^8.1.0",
     "bulma": "^0.9.0",


### PR DESCRIPTION


## Description
<!-- Concisely describe what the pull request does. -->
Updates vocabulary version to the latest version.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
