### PR TITLE
Add the missing links to the Outreachy rounds

### DIFF
--- a/content/internships/history/contents.lr
+++ b/content/internships/history/contents.lr
@@ -50,10 +50,10 @@ CC has participated in Google Summer of Code seven times up to 2013, and twice s
 
 CC participated in Outreachy twice since 2019.
 
-* [Outreachy May 2020 - August 2020]
+* [Outreachy May 2020 - August 2020](https://www.outreachy.org/outreachy-may-2020-internship-round/)
     * [Open Source Blog posts](/blog/categories/outreachy-2020/)
     * [Welcome Our Interns from Google Summer of Code and Outreachy!](https://creativecommons.org/2020/05/11/welcome-interns-google-summer-of-code-and-outreachy/)
-* [Outreachy December 2019 - March 2020]
+* [Outreachy December 2019 - March 2020](https://www.outreachy.org/december-2019-to-march-2020-internship-round/)
     * [Open Source Blog posts](/blog/categories/outreachy-2019-20/)
     * [Meet Our 2020 Interns From Outreachy](https://creativecommons.org/2019/12/10/2020-outreachy-interns/)
 


### PR DESCRIPTION
## Fixes
The Outreachy rounds on the internship history page did not have the links in the Markdown anchor tags `[](...)`, causing them to appear enclosed in `[ ]`. This is fixed by this PR.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
