### PR TITLE
Remove localhost from community team link

### DIFF
--- a/content/blog/entries/automate-github-for-more-than-CI CD/contents.lr
+++ b/content/blog/entries/automate-github-for-more-than-CI CD/contents.lr
@@ -17,7 +17,7 @@ In late 2018, in the midst of being acquired by Microsoft, GitHub [launched Gith
 
 In a [2018 TechCrunch interview](https://techcrunch.com/2018/10/16/github-launches-actions-its-workflow-automation-tool/), GitHub's then head of platform acknowledged the usefulness of actions for more than CI/CD. "I see CI/CD as one narrow use case of actions. It’s so, so much more,” Lambert stressed. “And I think it’s going to revolutionize DevOps because people are now going to build best in breed deployment workflows for specific applications and frameworks, and those become the de facto standard shared on GitHub. […] It’s going to do everything we did for open source again for the DevOps space and for all those different parts of that workflow ecosystem."
 
-At Creative Commons, we use Github Actions and Bots on many of [our open-source projects](https://github.com/creativecommons?type=source) for more than CI/CD—to manage our [community team](http://localhost:5000/community/community-team/); to automate repository health; and to automate tedious but frequent tasks. The following examples are just a small snapshot of our existing and in-progress automations.
+At Creative Commons, we use Github Actions and Bots on many of [our open-source projects](https://github.com/creativecommons?type=source) for more than CI/CD—to manage our [community team](/community/community-team/); to automate repository health; and to automate tedious but frequent tasks. The following examples are just a small snapshot of our existing and in-progress automations.
 
 ## Example automations
 


### PR DESCRIPTION
Small bugfix removing localhost from a link to our community team in: `/blog/entries/automate-github-for-more-than-CI%20CD/`


[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
