### PR TITLE
Update documentation about the new standard labels

### DIFF
--- a/content/contributing-code/github-repo-guidelines/contents.lr
+++ b/content/contributing-code/github-repo-guidelines/contents.lr
@@ -37,9 +37,11 @@ All GitHub repositories should have the following items to be considered fully r
 - [Support resources](https://help.github.com/en/articles/adding-support-resources-to-your-project). GitHub pulls the default `SUPPORT.md` file from our [`.github` repository](https://github.com/creativecommons/.github) automatically, but if you want/need to customize it, create it in your repository.
 
 ## Standard Labels
-All repositories must contain a set of standard labels, [documented here](https://github.com/creativecommons/ccos-scripts/blob/master/normalize_repos/labels.py). You don't have to set these up manually. CC staff can run [a script](https://github.com/creativecommons/ccos-scripts/tree/master/normalize_repos) that to make sure all repositories have this label.
 
-Repositories may contain additional custom labels as well. It is recommended that custom labels be explained in the contribution guidelines for that project.
+All repositories must contain a set of standard labels, [listed here](https://github.com/creativecommons/ccos-scripts/blob/master/normalize_repos/labels.json), in addition to repository-specific skill labels, [listed here](https://github.com/creativecommons/ccos-scripts/blob/master/normalize_repos/skills.json).
+You don't have to set these up manually. The labels are [automatically managed](https://github.com/creativecommons/ccos-scripts/tree/master/normalize_repos) on all CC repositories, and so, must not be renamed.
+
+Repositories may contain additional custom labels as well which will remain unaffected by the sync. It is recommended that custom labels be explained in the contribution guidelines for that project.
 
 ## Branch Protections
 


### PR DESCRIPTION
## Description
This PR fixes broken links and updates the text to reference the new standard labels incorporated across CC repos.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
