### PR TITLE
Replace deprecated label with the new label name

### DIFF
--- a/content/contributing-code/contents.lr
+++ b/content/contributing-code/contents.lr
@@ -60,7 +60,7 @@ If you want to work on something that there is no GitHub issue for, follow these
 
 1. Create a a new GitHub issue associated with the relevant repository and propose your change there. Be sure to include implementation details and the rationale for the proposed change.
     * We are very reluctant to accept random pull requests without a related issue created first.
-2. The issue will automatically have the `not ready for work` label applied. Wait for a project maintainer to evaluate your issue and decide whether it's something that we will accept a pull request for.
-3. Once the project maintainer has approved the issue and removed the `not ready for work` label, you may start work on code as described in the "Contribution process" section above.
+2. The issue will automatically have the `🚦 status: awaiting triage` label applied. Wait for a project maintainer to evaluate your issue and decide whether it's something that we will accept a pull request for.
+3. Once the project maintainer has approved the issue and removed the `🚦 status: awaiting triage` label, you may start work on code as described in the "Contribution process" section above.
 
 When in doubt, ask a question on [one of our community forums](/community/).

--- a/content/contributing-code/contents.lr
+++ b/content/contributing-code/contents.lr
@@ -60,7 +60,7 @@ If you want to work on something that there is no GitHub issue for, follow these
 
 1. Create a a new GitHub issue associated with the relevant repository and propose your change there. Be sure to include implementation details and the rationale for the proposed change.
     * We are very reluctant to accept random pull requests without a related issue created first.
-2. The issue will automatically have the `🚦 status: awaiting triage` label applied. Wait for a project maintainer to evaluate your issue and decide whether it's something that we will accept a pull request for.
-3. Once the project maintainer has approved the issue and removed the `🚦 status: awaiting triage` label, you may start work on code as described in the "Contribution process" section above.
+2. The issue will automatically have the <span class="gh-label status-darker">🚦 status: awaiting triage</span> label applied. Wait for a project maintainer to evaluate your issue and decide whether it's something that we will accept a pull request for.
+3. Once the project maintainer has approved the issue and removed the <span class="gh-label status-darker">🚦 status: awaiting triage</span> label, you may start work on code as described in the "Contribution process" section above.
 
 When in doubt, ask a question on [one of our community forums](/community/).


### PR DESCRIPTION
## Fixes
Fixes #533 by @dhruvkb 

## Description
Changes the old labels to the new ones.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
