### PR TITLE
Update og_image.html to fix quotes

### DIFF
--- a/themes/vocabulary_theme/templates/macros/og_image.html
+++ b/themes/vocabulary_theme/templates/macros/og_image.html
@@ -15,7 +15,7 @@
     {% if author and author.md5_hashed_email %}
       {% set gravatarURL = 'https://secure.gravatar.com/avatar/' + author.md5_hashed_email + '?size=300&d=mp' %}
       {% set queryParams = queryParams + '&images=' + gravatarURL %}
-      {% set pageTitle = page.title + '<br><sm style="font-size:70px;">By '+ render_author_name(author) + '</sm>'  %}
+      {% set pageTitle = page.title + "<br><sm style='font-size:70px;'>By " + render_author_name(author) + "</sm>"  %}
     {% endif  %}
   {% endif %}
 


### PR DESCRIPTION
I put double quotes _inside_ of the og image urls 🤦 on blog pages:

example: https://opensource.creativecommons.org/blog/entries/summary-my-gsod-2020-journey/

```
https://cc-og-image.vercel.app/Summary: My GSoD 2020 Journey<br><sm style="font-size:70px;">By Ariessa Norramli</sm>.png?&md=1&fontFamily=roboto-condensed&fontSize=100px&images=https%3A%2F%2Fcc-vocabulary.netlify.app%2Flogos%2Fproducts%2Fopen_source.svg%23opensource&images=https://secure.gravatar.com/avatar/6ee7af2da22737fd49ce56adc226d2cb?size=300&d=mp
```

This PR removes them.