### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 # These users own any files in the specified directory and 
 # any of its subdirectories.
 /webpack/ @creativecommons/frontend-engineers
+* @creativecommons/ct-cc-open-source-maintainers


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.