### PR TITLE
Conditional Rendering of Issue Finder App

### DIFF
--- a/webpack/js/issue-finder.js
+++ b/webpack/js/issue-finder.js
@@ -2,5 +2,6 @@ import Vue from 'vue';
 import {App} from './components'
 
 $(document).ready(function () {
-  window.app = new Vue(App)
+  if (window.location.pathname == '/contributing-code/issue-finder/')
+    window.app = new Vue(App)
 })


### PR DESCRIPTION
## Fixes
Fixes #585 by @shubhanshu02

## Description
The warning `Cannot Find Element: #vue-app` is visible on all pages except the Issue Finder. Vue is trying to render the Issue Finder component from webpack/js/component.js on every page, but since the div with `id="vue-app"` is available only on Issue Finder, the warning is visible.

## Technical details
I changed the condition to check if the `pathname` is `/contributing-code/issue-finder/`. This allows the rendering of the Issue Finder component only on Issue Finder page, not on every page.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
