### PR TITLE
Fixes parent link in 'Contribution Guidelines' section. Fixes #627

### DIFF
--- a/themes/vocabulary_theme/templates/page-with-toc.html
+++ b/themes/vocabulary_theme/templates/page-with-toc.html
@@ -22,12 +22,12 @@
                   {% for href, title in [
                     ['/contributing-code/projects', 'Project List'],
                     ['/contributing-code/issue-finder', 'Issue Finder'],
-                    ['/contributing-code/contributing-code', 'Contribution Guidelines'],
+                    ['/contributing-code', 'Contribution Guidelines'],
                     ['/contributing-code/usability', 'Usability'],
                   ] %}
                     <li>
                     <a class="{% if this.path == href %} is-active {% endif%} link" href="{{ href|url }}">{{ title }}</a>
-                    {% if (href == '/contributing-code/contributing-code') %}
+                    {% if (href == '/contributing-code') %}
                       <ul>
                       {% for href, title in [
                         ['/contributing-code/pr-guidelines', 'Pull Request Guidelines'],


### PR DESCRIPTION
## Fixes
Fixes #627 by @cuibonobo

## Description
Fixes the parent link in the 'Contribution Guidelines' section of the site so that it no longer points to a non-existent page.

## Screenshots
The 'Contribution Guidelines' parent link now appears with the correct styles when you are on the 'Contribution Guidelines' page.
![2022-01-12 12_33_45-Window](https://user-images.githubusercontent.com/391241/149192028-88392ead-8525-4495-ba7e-f111c445afa2.png)


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
