### PR TITLE
Fixed alignment of homepage Get Involved list

### DIFF
--- a/content/contents.lr
+++ b/content/contents.lr
@@ -47,11 +47,11 @@ links_integrate:
 
 <img src="./integrate.svg">
 
-<h4 class="heading">Integrate CC licenses into your project</h4>
+<h4 class="heading">Integrate CC licenses</h4>
 
 <div class="list">
   <h5 class="link-heading"><a href="https://github.com/creativecommons/chooser/" class="has-text-forest-green">Chooser</a></h5>
-  <p class="link-caption">CC license selection tool</p>
+  <p class="link-caption">CC license selection tool for your project.</p>
 
   <h5 class="link-heading"><a href="https://creativecommons.org/platform/toolkit/" class="has-text-forest-green">Platform Toolkit</a></h5>
   <p class="link-caption">Give users the option to openly license their content.</p>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #703 by @adidevs

## Description
<!-- Concisely describe what the pull request does. -->
The lists in the Get Involved section of the homepage are not aligned due to longer heading of the "Integrate CC licenses into your project". This PR fixes that by refactoring the content as per the file changes to align the lists.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->
BEFORE:
![image](https://user-images.githubusercontent.com/99022811/223896994-71d90396-bd2d-4b73-8834-4532d35b3e28.png)

AFTER: 
![image](https://user-images.githubusercontent.com/99022811/223897082-9852d216-b143-420f-816e-20960413a20e.png)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
