### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 # code owners must be on the same line. If the code owners are not on the same
 # line, the pattern matches only the last mentioned code owner.
 * @creativecommons/technology @creativecommons/ct-cc-open-source-core-committers @creativecommons/ct-cc-open-source-maintainers
+* @creativecommons/ct-cc-open-source-collaborators


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.