### PR TITLE
Fix: prevent text overflow in card titles on smaller screens

### DIFF
--- a/webpack/sass/project-ideas.scss
+++ b/webpack/sass/project-ideas.scss
@@ -92,3 +92,7 @@
     }
   }
 }
+
+.card-title {
+  word-wrap: break-word;
+}


### PR DESCRIPTION


## Fixes
- Fixes #829 by @Queen-codes

## Description
This pull request addresses a bug where card titles overflowed on smaller screen sizes. It adds a CSS rule to ensure that text within `.card-title` wraps properly, preventing it from extending beyond the card's boundaries.

## Technical details
- Added `word-wrap: break-word;` to the `.card-title` class in `project-ideas.scss` to handle long text.
- This change ensures better readability and a more responsive design, especially on mobile devices.

## Tests
1. Navigate to the issue finder page.
2. Resize the window to a smaller screen size.
3. Verify that long card titles no longer overflow and are wrapped properly within their containers.

## Screenshots

### before
![before](https://github.com/user-attachments/assets/b4037e0c-58d6-4928-bf65-e73e1a37097c)

### after
![after](https://github.com/user-attachments/assets/7ce74219-3b53-4fb3-8ef5-1b1802157a4e)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
