### PR TITLE
Feature: Implement Excerpt Field in Blog Post Format

### DIFF
--- a/content/community/write-a-blog-post/contents.lr
+++ b/content/community/write-a-blog-post/contents.lr
@@ -54,6 +54,9 @@ Once you have written your post, you can either send it to us (Markdown is easie
   ---
   pub_date: Replace this text with the publication date in YYYY-MM-DD format.
   ---
+  excerpt: Replace this text by providing a brief summary of your post to capture readers' interest.
+  If you do not add an excerpt, the first 100 words of your content will be used automatically.
+  ---
   body:
   Replace this text with your post's content (minus the title). This field accepts Markdown for formatting.
   If you're including images, you can use the Markdown image syntax i.e. ![image-title](image-file-name.jpg).

--- a/content/community/write-a-blog-post/contents.lr
+++ b/content/community/write-a-blog-post/contents.lr
@@ -54,7 +54,7 @@ Once you have written your post, you can either send it to us (Markdown is easie
   ---
   pub_date: Replace this text with the publication date in YYYY-MM-DD format.
   ---
-  excerpt: Replace this text by providing a brief summary of your post to capture readers' interest.
+  excerpt: Replace this text with a brief summary of your post to capture readers' interest.
   If you do not add an excerpt, the first 100 words of your content will be used automatically.
   ---
   body:

--- a/models/blog-post.ini
+++ b/models/blog-post.ini
@@ -29,3 +29,7 @@ type = strings
 [fields.body]
 label = Body
 type = markdown
+
+[fields.excerpt]
+label = Excerpt
+type = text

--- a/models/blog-post.ini
+++ b/models/blog-post.ini
@@ -32,4 +32,4 @@ type = markdown
 
 [fields.excerpt]
 label = Excerpt
-type = text
+type = markdown

--- a/themes/vocabulary_theme/templates/macros/posts.html
+++ b/themes/vocabulary_theme/templates/macros/posts.html
@@ -9,7 +9,7 @@
         <h4 class="b-header"><a class="blog-title" href="{{ post|url }}">{{ post.title }}</a></h4>
         {{ render_authors_byline(post) }}
         <div class="excerpt">
-          {{ post.body | excerpt | string | striptags() | truncate(100) }}
+          {{ post.excerpt | default(post.body) | striptags | truncate(100) }}
         </div>
       </div>
     </article>

--- a/themes/vocabulary_theme/templates/macros/posts.html
+++ b/themes/vocabulary_theme/templates/macros/posts.html
@@ -9,7 +9,11 @@
         <h4 class="b-header"><a class="blog-title" href="{{ post|url }}">{{ post.title }}</a></h4>
         {{ render_authors_byline(post) }}
         <div class="excerpt">
-          {{ post.excerpt | default(post.body) | striptags | truncate(100) }}
+        {% if post.excerpt %}
+          {{ post.excerpt }}
+        {% else %}
+          {{ post.body | excerpt | string | striptags() | truncate(100) }}
+        {% endif %}
         </div>
       </div>
     </article>


### PR DESCRIPTION
## Fixes
- Fixes #840 by @Queen-codes

## Description
This PR enhances the blog post feature by adding the ability for authors to include custom excerpts for each blog post. It allows for better control over the preview content that readers will see, providing an engaging summary for the post. If no custom excerpt is provided, the first 100 words of the blog post body will be used by default . This improves content presentation and increases the chances of engaging readers right from the preview.

## Technical Details

1. Added an `excerpt` field to `contents.lr` for authors to input custom excerpts 
    for blog posts.
2. Updated  `post.html` to handle and display the excerpt field and provided a default  
    mechanism to use first 100 words if the excerpt is not provided.
3. Modified the `blog-post.ini` to include excerpt field.

## Tests
1. Open the homepage of the project.
2. Go to Blog> CC Open Source Blog
4. See Changes
## Screenshots
Sample Blog for Testing the Excerpt Field :
<img width="1067" alt="Screenshot 2024-11-06 at 10 59 57 PM" src="https://github.com/user-attachments/assets/5c18fef7-de70-45f0-b9cb-53b0963d6436">

Excerpt Field preview:
<img width="1067" alt="Screenshot 2024-11-06 at 10 53 24 PM" src="https://github.com/user-attachments/assets/f787ff6b-a9ca-4fe3-889d-001448a4252b">


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
