### PR TITLE
Refactor Recent Posts Section for Responsive Design and Consistent Layout

### DIFF
--- a/webpack/sass/home-page.scss
+++ b/webpack/sass/home-page.scss
@@ -171,15 +171,34 @@
   }
 }
 
+// Card styling within the blog entries section
+.card.entry-post.horizontal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 30px;
+  border-radius: 25px;
+  background-color: #FFFFFF;
+  padding: 20px; /* Adjust padding as needed */
+  margin-top: 2rem;
+  
+  // Image styling inside the card
+  .blog-image {
+    width: auto;
+    height: 8rem;
+    margin-top: -3rem;
+  }
+}
+
 .blog-entries {
   .column {
     border-bottom: 0.1875rem solid $color-light-gray;
   }
-  /* last row, irrespective of the number of elements */
-  .column:nth-last-child(-n + 3):nth-child(3n + 1), /* first element of the last row */
+    /* last row, irrespective of the number of elements */
+    .column:nth-last-child(-n + 3):nth-child(3n + 1), /* first element of the last row */
     .column:nth-last-child(-n + 3):nth-child(3n + 1) ~ .column /* all its following elements */ {
-    border-bottom: none;
-  }
+      border-bottom: none;
+    }
 
   .blog-entry {
     @extend .padding-vertical-larger;


### PR DESCRIPTION
## Fixes
- Fixes #761 by @Kirsty21

## Description
This pull request addresses the issue with the "Recent Posts" section on the contributor page. The layout on desktop screens was not responsive, and the posts were not placed into individual cards, which affected the design consistency across different screen sizes. This update refactors the layout, placing each post into individual cards and making the layout fully responsive for both mobile and desktop views.

## Technical Details
- The recent posts section was refactored to include individual cards for each post.
- Flexbox layout was used to achieve better spacing and alignment within the cards.
- The design was synced with the existing styling to maintain consistency.

## Tests
- To verify the changes, review the recent posts section on various screen sizes, ensuring that the posts are displayed in cards and that the layout adjusts smoothly between mobile and desktop.
- Check for any alignment issues or visual inconsistencies.

## Screenshots
before
<img width="1470" alt="Screenshot 2024-12-07 at 23 10 57" src="https://github.com/user-attachments/assets/1e6c2847-5e07-42b2-b7dd-6829fe1fefa0">

after
<img width="1470" alt="Screenshot 2024-12-07 at 23 09 24" src="https://github.com/user-attachments/assets/34dcf513-dfec-42e2-b71f-eb354098cf74">


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
