### PR TITLE
Fix vocabulary.css import

### DIFF
--- a/assets/static/css/style.css
+++ b/assets/static/css/style.css
@@ -1,3 +1,3 @@
-@import "/assets/static/vocabulary/css/vocabulary.css" layer(vocabulary);
+@import "/static/vocabulary/css/vocabulary.css" layer(vocabulary);
 
 /*put local styles here*/

--- a/themes/vocabulary_theme/templates/layout.html
+++ b/themes/vocabulary_theme/templates/layout.html
@@ -6,7 +6,6 @@
 <link rel="icon" href="{{ '/static/vocabulary/favicon/favicon.svg' |url }}" type="image/svg+xml">
 <link rel="manifest" href="{{ '/static/vocabulary/favicon/manifest.webmanifest' |url }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/static/vocabulary/favicon/apple-touch-icon.png' |url}}" />
-<link rel="stylesheet" href="{{ '/static/vocabulary/css/vocabulary.css'|url }}">
 <link rel="stylesheet" href="{{ '/static/css/style.css'|url }}">
 <link rel="stylesheet" href="{{ get_pygments_stylesheet()|url }}">
 <meta property="og:site_name" content="Creative Commons" />


### PR DESCRIPTION
## Fixes
Browser console error:
```
The stylesheet http://127.0.0.1:5000/assets/static/vocabulary/css/vocabulary.css
 was not loaded because its MIME type, “text/html”, is not “text/css”.
```
(`/assets/static/vocabulary/css/vocabulary.css` is HTML because it is a 404 page)

## Description
Fix `vocabulary.css` import:
1. `assets/static/css/style.css`: correct `vocabulary.css` path
2.  `themes/vocabulary_theme/templates/layout.html` remove `vocabulary.css` (since it is now successfully included from `style.css`)

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
